### PR TITLE
Always return an object from calls to the PushBullet APIs, even for errors

### DIFF
--- a/pushbullet.js
+++ b/pushbullet.js
@@ -246,14 +246,26 @@ var PushBullet = (function() {
     };
 
     var handleResponse = function(ajax) {
-        if(ajax.status !== httpResGood && ajax.status !== httpResNoCont) {
-            throw new Error(ajax.status + ": " + ajax.response);
-        }
+        var response;
+
         try {
-            return JSON.parse(ajax.response);
-        } catch(err) {
-            return ajax.response;
+            response = JSON.parse(ajax.response);
         }
+        catch (err) {
+            response = {
+                response: ajax.response
+            };
+        }
+
+        if(ajax.status !== httpResGood) {
+            response.httpStatus = ajax.status;
+
+            if (ajax.status !== httpResNoCont) {
+                throw response;
+            }
+        }
+
+        return response;
     };
 
     return pb;


### PR DESCRIPTION
Previously, an error response from the PushBullet API would have resulted in a modified JSON string that could not be parsed as JSON (Chrome 39, beta) being returned to the caller. Now it returns an object with an "error" property, the value of which is the parsed error object from PushBullet. If no JSON error was returned from PushBullet, there will at least be a "response" property with the raw value of the AJAX response (if any). Additionally, an "httpStatus" property will be present in the object returned (or thrown) to the caller when the HTTP status code is !== 200.

This allows callers to pushbullet.js to display PushBullet's nice friendly error messages to their users, rather than a messy string that's basically JSON with an HTTP status code tacked on the front of it.
