### PR TITLE
New functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ PushBullet.APIKey = "<your api key here>";
 * [PushBullet.pushHistory](#pushbulletpushhistory)
 * [PushBullet.devices](#pushbulletdevices)
 * [PushBullet.deleteDevice](#pushbulletdeletedevice)
+* [PushBullet.createDevice](#pushbulletcreatedevice)
 * [PushBullet.contacts](#pushbulletcontacts)
 * [PushBullet.deleteContact](#pushbulletdeletecontact)
 * [PushBullet.user](#pushbulletuser)
@@ -308,6 +309,47 @@ Example return value:
 
 ```javascript
 {}
+```
+---
+### PushBullet.createDevice
+`PushBullet.createDevice(dev, callback)` - Creates a new device.
+* `dev` - the information of a new device.  Expects a JSONified version of the type parameters [here](https://docs.pushbullet.com/v2/devices).
+* `callback` - Optional callback that expects an `err` and a `res` parameter
+
+Example for synchronous:
+
+```javascript
+var dev = {nickname: '<your device nickname>', type: '<your device stream>'};
+var res = PushBullet.createDevice(dev);
+console.log(res);
+```
+
+Example for asynchronous:
+
+```javascript
+var dev = {nickname: '<your device nickname>', type: '<your device stream>'};
+PushBullet.createDevice(dev, function(err, res) {
+    if(err) {
+        throw err;
+    } else {
+        console.log(res);
+    }
+});
+```
+
+Example return value:
+
+```javascript
+{
+    "active": true,
+    "created": 1431196067.580387,
+    "iden": "juYoChWgSHsjkktADfgroc",
+    "kind": "stream",
+    "modified": 1431196067.580392,
+    "nickname": "HelloWorld",
+    "pushable": true,
+    "type": "stream"
+}
 ```
 ---
 ### PushBullet.contacts

--- a/pushbullet.js
+++ b/pushbullet.js
@@ -134,18 +134,24 @@ var PushBullet = (function() {
         }
     };
 
-    pb.pushHistory = function(modifiedAfter, cursor, callback) {
-        if(typeof modifiedAfter === 'function') {
-            callback = modifiedAfter;
-            modifiedAfter = null;
+    pb.updatePush = function(pushId, params, callback) {
+        var res = ajaxReq(pbPush + "/" + pushId, "POST", params, false, callback);
+        if(!callback) {
+            return res;
+        }
+    };
+
+    pb.pushHistory = function(parameters, cursor, callback) {
+        if(typeof parameters === 'function') {
+            callback = parameters;
+            parameters = null;
         } else if (typeof cursor === 'function') {
             callback = cursor;
             cursor = null;
         }
-        var parameters = null;
-        if(modifiedAfter) {
+        if(typeof parameters !== 'object') {
             parameters = {
-                modified_after: modifiedAfter
+                modified_after: parameters
             };
         }
         if(cursor) {

--- a/pushbullet.js
+++ b/pushbullet.js
@@ -158,8 +158,8 @@ var PushBullet = (function() {
         }
     };
 
-    pb.devices = function(callback) {
-        var res = ajaxReq(pbDevice, "GET", null, false, callback);
+    pb.devices = function(callback, params) {
+        var res = ajaxReq(pbDevice, "GET", params, false, callback);
         if(!callback) {
             return res;
         }

--- a/pushbullet.js
+++ b/pushbullet.js
@@ -172,6 +172,13 @@ var PushBullet = (function() {
         }
     };
 
+    pb.createDevice = function(dev, callback) {
+        var res = ajaxReq(pbDevice, "POST", dev, false, callback);
+        if(!callback) {
+            return res;
+        }
+    };
+
     pb.contacts = function(callback) {
         var res = ajaxReq(pbContact, "GET", null, false, callback);
         if(!callback) {


### PR DESCRIPTION
Added support to POST /v2/devices to create a device.

Added support to supply extra params to GET /v2/devices, which is useful to exclude deleted content.

Added support to supply extra params to GET /v2/pushes, which is useful to exclude deleted content. Backwards compatibility still works with existing modified_after.
